### PR TITLE
fix: nestjs multiline-ternary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.1
+
+_Jan 8, 2024_
+
+- Remove 'multiline-ternary' rule of ESLint for Nestjs.
+- Add 'no-nested-ternary' rule of ESLint for  Nest.
+
 ## 2.0.0
 
 _Jan 3, 2024_

--- a/config/nestjs/.eslintrc.js
+++ b/config/nestjs/.eslintrc.js
@@ -72,7 +72,7 @@ module.exports = {
     'no-console': 'error',
     'no-mixed-operators': 'error',
     'keyword-spacing': 'error',
-    'multiline-ternary': ['error', 'never'],
+    'no-nested-ternary': 2,
     'no-undef': 'error',
     'no-whitespace-before-property': 'error',
     'nonblock-statement-body-position': 'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcian/lint-sage",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "This package designed to simplify the configuration of your projects. This package automates the setup of essential tools and configurations to ensure a clean and consistent codebase.",
   "bin": {
     "lint-sage": "index.js"


### PR DESCRIPTION
- Remove the 'multiline-ternary' rule of ESLint for Nestjs.
- Add the 'no-nested-ternary' rule of ESLint for  Nest.