### PR TITLE
fix: close double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.2
+
+_Jan 9, 2024_
+
+- Fix the double quotation issue in the commands scripts.lint and scripts.prepare
+
 ## 2.0.1
 
 _Jan 8, 2024_

--- a/index.js
+++ b/index.js
@@ -172,14 +172,14 @@ async function init() {
     angular: 'ng lint',
   };
 
-  execSync(`npm pkg set scripts.lint="${eslintRunCmds[technology]}`, {
+  execSync(`npm pkg set scripts.lint="${eslintRunCmds[technology]}"`, {
     stdio: "inherit",
   });
 
   console.log("Required plugins installed successfully.");
 
   console.log("Adding husky script");
-  execSync(`npm pkg set scripts.prepare="husky install`, {
+  execSync(`npm pkg set scripts.prepare="husky install"`, {
     stdio: "inherit",
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcian/lint-sage",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "This package designed to simplify the configuration of your projects. This package automates the setup of essential tools and configurations to ensure a clean and consistent codebase.",
   "bin": {
     "lint-sage": "index.js"


### PR DESCRIPTION
- Fix the double quotation issue in the commands `scripts.lint` and `scripts.prepare`